### PR TITLE
Add NeuroHTTP — AI-native HTTP server under AI Web Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ _Stay current with AI developments without drowning in noise._
 
 Tools for building and deploying AI applications. 
 
+### 🌐 AI Web Infrastructure
+
+- [NeuroHTTP](https://github.com/okba14/NeuroHTTP) — Ultra-lightweight HTTP server written in pure C and Assembly, designed for embedded AI inference at the HTTP layer.  
+  *Optimized for low-latency AI requests and cross-platform deployment. MIT licensed.*
+
 ### 💬 Models
 - [ChatGPT](https://openai.com/chatgpt/overview/) — Best for general coding + reasoning.
 - [Claude](https://www.anthropic.com/claude) — Best for long-context analysis and structured thinking.


### PR DESCRIPTION
### Summary
Adding **NeuroHTTP**, an ultra-lightweight AI-native HTTP server written in pure C and Assembly.

### Why it’s awesome
- Embeds neural inference directly at the HTTP layer.
- Fully open-source (MIT).
- Designed for high-performance, low-level AI workloads and embedded systems.

🔗 [Project Repository](https://github.com/okba14/NeuroHTTP)
