### PR TITLE
Add FrostByte: Memory management utility for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Tools for building and deploying AI applications.
 - [Claude Code](https://www.anthropic.com/claude) — IDE extensions with long-context code edits.
 - [GitHub Copilot](https://github.com/features/copilot) — In-IDE code completion, chat, and refactors.
 - [Cursor](https://cursor.sh/) — LLM-powered IDE for multi-file edits and codebase-aware chat.
+- [FrostByte](https://github.com/VladislavTsytrikov/frostbyte) - An autonomous daemon for Linux (GNOME/Wayland) that saves RAM by auto-suspending idle background applications.
   
 ### 🎨 Multimedia AI Tools
 


### PR DESCRIPTION
Hi! I'd like to suggest adding FrostByte to the Code & Developer Tools section.

FrostByte is a background daemon that helps developers reclaim RAM on Linux (GNOME/Wayland) by auto-suspending inactive background applications. It's a modern, zero-config tool designed for better system performance.

Link: https://github.com/VladislavTsytrikov/frostbyte