### PR TITLE
Add Podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ _Stay current with AI developments without drowning in noise._
 
 ## 🎙 Podcasts
 - [Chain of Thought](https://chainofthought.show/) — Weekly conversations with AI leaders exploring inference infrastructure, developer tools, and AI strategy.
-- [How I AI](https://www.youtube.com/@howiai) — Claire Vo interviews builders and operators using AI to change how they work.
+- [How I AI](https://www.lennysnewsletter.com/s/how-i-ai) — Claire Vo interviews builders and operators on how they actually use AI in their work. Part of the Lenny's Podcast network.
 - [Latent Space](https://www.latent.space/podcast) — Technical deep dives into AI engineering, LLMs, and the developer tooling ecosystem.
 - [Practical AI](https://practicalai.fm/) — Making artificial intelligence practical, productive, and accessible to everyone.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ _Stay current with AI developments without drowning in noise._
 - [AI Engineer](https://newsletter.owainlewis.com)
 
 ## 🎙 Podcasts
-- [Chain of Thought](https://chainofthought.show/) — Weekly conversations with AI leaders exploring inference infrastructure, developer tools, and AI strategy. Hosted by Conor Bronsdon.
+- [Chain of Thought](https://chainofthought.show/) — Weekly conversations with AI leaders exploring inference infrastructure, developer tools, and AI strategy.
+- [How I AI](https://www.youtube.com/@howiai) — Claire Vo interviews builders and operators using AI to change how they work.
+- [Latent Space](https://www.latent.space/podcast) — Technical deep dives into AI engineering, LLMs, and the developer tooling ecosystem.
+- [Practical AI](https://practicalai.fm/) — Making artificial intelligence practical, productive, and accessible to everyone.
 
 ## ⚡ Tools
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ _Stay current with AI developments without drowning in noise._
 
 ## 🎙 Podcasts
 - [Chain of Thought](https://chainofthought.show/) — Weekly conversations with AI leaders exploring inference infrastructure, developer tools, and AI strategy.
-- [How I AI](https://www.lennysnewsletter.com/s/how-i-ai) — Claire Vo interviews builders and operators on how they actually use AI in their work. Part of the Lenny's Podcast network.
+- [How I AI](https://www.youtube.com/@howiaipodcast) — Claire Vo interviews builders and operators on how they actually use AI in their work. Part of the Lenny's Podcast network.
 - [Latent Space](https://www.latent.space/podcast) — Technical deep dives into AI engineering, LLMs, and the developer tooling ecosystem.
 - [Practical AI](https://practicalai.fm/) — Making artificial intelligence practical, productive, and accessible to everyone.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ _Stay current with AI developments without drowning in noise._
 - [Superhuman AI](https://www.superhuman.ai/)
 - [AI Engineer](https://newsletter.owainlewis.com)
 
+## 🎙 Podcasts
+- [Chain of Thought](https://chainofthought.show/) — Weekly conversations with AI leaders exploring inference infrastructure, developer tools, and AI strategy. Hosted by Conor Bronsdon.
+
 ## ⚡ Tools
 
 Tools for building and deploying AI applications. 


### PR DESCRIPTION
Adding a Podcasts section (parallel to the existing Newsletters section) with curated AI podcasts:

- [Chain of Thought](https://chainofthought.show/) — AI infrastructure, developer tools, and strategy
- [How I AI](https://www.youtube.com/@howiaipodcast) — Practical AI usage from builders and operators
- [Latent Space](https://www.latent.space/podcast) — Technical AI engineering deep dives
- [Practical AI](https://practicalai.fm/) — Making AI practical and accessible

These are actively maintained, well-known podcasts that complement the existing learning resources in this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "🎙 Podcasts" section to the resources, introducing four podcast recommendations: Chain of Thought, How I AI, Latent Space, and Practical AI.
  * Each podcast entry includes a brief description to help readers discover audio resources on AI and related topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->