### PR TITLE
Add Podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ _Stay current with AI developments without drowning in noise._
 - [Superhuman AI](https://www.superhuman.ai/)
 - [AI Engineer](https://newsletter.owainlewis.com)
 
+## 🎙 Podcasts
+
+- [Chain of Thought](https://chainofthought.show/) — Interviews with AI leaders on inference infrastructure, developer tools, and strategy.
+- [How I AI](https://www.youtube.com/@howiaipodcast) — Claire Vo talks to builders about how they actually use AI day to day.
+- [Latent Space](https://www.latent.space/podcast) — Technical AI engineering podcast focused on LLMs and developer tooling.
+- [Practical AI](https://practicalai.fm/) — AI made practical and accessible, from the Changelog network.
+- [TWIML AI](https://twimlai.com/) — Interviews with researchers and practitioners across ML.
+
 ## ⚡ Tools
 
 Tools for building and deploying AI applications. 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Stay current with AI developments without drowning in noise._
 - [AI Engineer](https://newsletter.owainlewis.com)
 
 ## 🎙 Podcasts
+_Listen to practical AI conversations on engineering, tooling, and research._
 
 - [Chain of Thought](https://chainofthought.show/) — Interviews with AI leaders on inference infrastructure, developer tools, and strategy.
 - [How I AI](https://www.youtube.com/@howiaipodcast) — Claire Vo talks to builders about how they actually use AI day to day.


### PR DESCRIPTION
Adds a Podcasts section parallel to the existing Newsletters section, with five actively maintained AI podcasts covering engineering, tooling, research, and practical applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Podcasts" section to the documentation with five curated podcast recommendations and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->