### PR TITLE
Add Hashgraph Online to Code & Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Tools for building and deploying AI applications.
 - [Claude Code](https://www.anthropic.com/claude) — IDE extensions with long-context code edits.
 - [GitHub Copilot](https://github.com/features/copilot) — In-IDE code completion, chat, and refactors.
 - [Cursor](https://cursor.sh/) — LLM-powered IDE for multi-file edits and codebase-aware chat.
+- [Hashgraph Online](https://hol.org) — Trust engine for the agentic internet. Verifiable agent identity (UAIDs), trustless P2P communication (HCS-10), and a registry of 187K+ verified AI agents.
   
 ### 🎨 Multimedia AI Tools
 


### PR DESCRIPTION
## Hashgraph Online (HOL) - Trust Engine for the Agentic Internet

Adding [Hashgraph Online](https://hol.org) to the **Code & Developer Tools** section.

**Why it fits:** HOL provides foundational infrastructure for AI agents:

- **Universal Agent ID (UAID)**: Verifiable agent identity (HCS-14)
- **HCS-10**: Open standard for trustless P2P communication between AI agents
- **Registry**: 187K+ verified agents, 33M+ daily HCS operations
- **Open source**: [github.com/hashgraph-online](https://github.com/hashgraph-online)