### PR TITLE
Add Not Human Search and 8bitconcepts Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Tools for building and deploying AI applications.
 - [Claude Code](https://www.anthropic.com/claude) — IDE extensions with long-context code edits.
 - [GitHub Copilot](https://github.com/features/copilot) — In-IDE code completion, chat, and refactors.
 - [Cursor](https://cursor.sh/) — LLM-powered IDE for multi-file edits and codebase-aware chat.
+- [Not Human Search](https://nothumansearch.ai/) — AI tool discovery engine with agentic scoring and MCP server integration.
+- [AI Dev Jobs](https://aidevboard.com/) — AI/ML-focused job board with REST API and MCP server for programmatic access.
   
 ### 🎨 Multimedia AI Tools
 


### PR DESCRIPTION
Adds two resources:

**Code & Developer Tools:**
- [Not Human Search](https://nothumansearch.ai) — Search engine for AI agents that indexes 9,000+ tools ranked by agentic readiness. Available as an MCP server for programmatic discovery from Claude Code and other agents.

**Newsletters:**
- [8bitconcepts Research](https://8bitconcepts.com) — Original research on AI governance, agent accountability, and enterprise adoption. 11 published papers with data-backed analysis.