### PR TITLE
Add 8bitconcepts research papers (Guides) + newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [Google Agents Companion Paper](https://www.kaggle.com/whitepaper-agent-companion) - Guide from Google
 - [OpenAI Cookbook](https://cookbook.openai.com/) — Example code, recipes, and best practices for working with OpenAI APIs.
 - [LLM Engineer Handbook](https://github.com/SylphAI-Inc/LLM-engineer-handbook) — A goldmine of useful links for AI engineers
+- [The Hallucination Budget (8bitconcepts)](https://8bitconcepts.com/research/the-hallucination-budget.html) — How to quantify hallucination cost and choose mitigation strategies that match actual risk tolerance.
+- [The Guardrails Gap (8bitconcepts)](https://8bitconcepts.com/research/the-guardrails-gap.html) — Why enterprise AI safety frameworks fail when agents start acting autonomously.
 
 #### 🤖 Frameworks 
 - [PocketFlow](https://the-pocket.github.io/PocketFlow/) — Extremely minimalist AI agent framework in just 100 lines of code. Fantastic way to learn.
@@ -93,6 +95,7 @@ _Stay current with AI developments without drowning in noise._
 - [AlphaSignal](https://alphasignal.ai/)
 - [Superhuman AI](https://www.superhuman.ai/)
 - [AI Engineer](https://newsletter.owainlewis.com)
+- [8bitconcepts Research](https://8bitconcepts.com/feed.xml) — Weekly independent research on enterprise AI adoption — agentic accountability, hallucination budgets, governance gaps.
 
 ## ⚡ Tools
 


### PR DESCRIPTION
Adding two 8bitconcepts research papers to **Guides & Playbooks** — both address practical AI engineering concerns that fit the current section's framing (patterns, pitfalls, tradeoffs):

- **[The Hallucination Budget](https://8bitconcepts.com/research/the-hallucination-budget.html)** — how to quantify hallucination cost and pick mitigation strategies that match actual risk tolerance. Useful for anyone shipping RAG/LLM systems where the wrong hallucination rate is a product problem, not just a model problem.
- **[The Guardrails Gap](https://8bitconcepts.com/research/the-guardrails-gap.html)** — why traditional enterprise AI safety frameworks break down once agents start acting autonomously. Complements the "Building Effective Agents" entry directly above.

Plus adding the [8bitconcepts RSS feed](https://8bitconcepts.com/feed.xml) to **Newsletters** — weekly independent research on enterprise AI adoption.

All three resources are free and readable without signup. Happy to trim if any feel off-fit.