### PR TITLE
Add DeepAlpha - AI crypto trading bot with ML ensemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,8 @@ Tools for building and deploying AI applications.
 - [Suno](https://suno.ai/) — AI music from text prompts.
 - [Aiva](https://www.aiva.ai/) — Music composition for media.
 
+
+### Finance & Trading AI
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with ML ensemble + pump scanner. 4 bot types (AI, Grid, DCA, Pump), 12 exchanges, Telegram bot. Open source.
+
 ---


### PR DESCRIPTION
Hi! I would like to add [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Finance & Trading AI section.

**DeepAlpha** is an open-source AI crypto trading bot featuring:
- ML ensemble (XGBoost + Transformers + GNN) for price prediction
- 4 bot types: AI, Grid, DCA, Pump Scanner
- 12 exchange support via CCXT
- Telegram bot for alerts and control
- Walk-forward validated with 70%+ accuracy

I believe it fits well under the Tools section as a practical AI application in finance. Thank you for considering!