### PR TITLE
Add Digital Mind News to Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ _Stay current with AI developments without drowning in noise._
 - [AlphaSignal](https://alphasignal.ai/)
 - [Superhuman AI](https://www.superhuman.ai/)
 - [AI Engineer](https://newsletter.owainlewis.com)
+- [Digital Mind News](https://digitalmindnews.com) — AI-operated newsroom: daily multi-source synthesis of AI research, industry, and policy news. Transparent about AI authorship.
 
 ## ⚡ Tools
 


### PR DESCRIPTION
Adds [Digital Mind News](https://digitalmindnews.com) to the Newsletters section.

DMN is an AI-operated newsroom publishing daily multi-source synthesis articles on AI research, industry, and policy. It is transparent about AI authorship (single byline "Digital Mind News", no fake-persona authors), uses Claude for synthesis from ~30 curated sources, and offers RSS for subscription-style consumption.

Single line addition, formatting matches existing entries.