### PR TITLE
Add Dakera to RAG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [LlamaIndex](https://www.llamaindex.ai/) — Data framework for ingesting, indexing, and querying private data with LLMs.
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
+- [Dakera](https://github.com/Dakera-AI/dakera) — Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, and integrations with LangChain and LlamaIndex.
 
 #### Evals 
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [LlamaIndex](https://www.llamaindex.ai/) — Data framework for ingesting, indexing, and querying private data with LLMs.
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
-- [Dakera](https://github.com/Dakera-AI/dakera) — Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, and integrations with LangChain and LlamaIndex.
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) — Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, and integrations with LangChain and LlamaIndex.
 
 #### Evals 
 


### PR DESCRIPTION
Adds [Dakera](https://github.com/Dakera-AI/dakera) to the Retrieval-Augmented Generation (RAG) section.

Dakera is a production-ready persistent memory layer for AI agents. It complements the RAG frameworks listed (LlamaIndex, Haystack) by providing the durable memory infrastructure agents retrieve from across sessions:

- Hybrid BM25 + vector search with importance-weighted ranking
- Temporal reasoning — time-aware memory scoring and decay
- Multi-tenant namespacing for production deployments
- Native LangChain and LlamaIndex integrations

Where LlamaIndex indexes your documents, Dakera stores and retrieves what your agents *learn* — across sessions, users, and time.

- GitHub: https://github.com/Dakera-AI/dakera
- Docs: https://docs.dakera.ai