### PR TITLE
Add Dakera to RAG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
 
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) — Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, and integrations with LangChain and LlamaIndex.
+
 #### Evals 
 
 - [OpenAI Evals](https://github.com/openai/evals) — OpenAI's framework for writing evals


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
