### PR TITLE
Add AI Models Catalog to 📊 Compare section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _Live benchmarks, pricing, and the latest model versions._
 - [OpenRouter](https://openrouter.ai/models) — Unified API + live pricing across ~300 models.
 - [LMArena](https://lmarena.ai/leaderboard) — Human-preference Elo rankings for text, image, and video.
 - [Artificial Analysis](https://artificialanalysis.ai/) — Speed, price, and quality benchmarks across providers.
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) — Structured YAML catalog of 4,587+ models across 95 providers with pricing, context windows, and capabilities. Interactive catalog at https://i-need-token.github.io/ai-models/
 
 ---
 


### PR DESCRIPTION
## Addition

- **Name:** AI Models Catalog
- **URL:** https://github.com/i-need-token/ai-models

## Description

Structured YAML catalog of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities. All data sourced from first-party APIs and official documentation.

Features:
- Interactive catalog with 25+ features (filter, sort, compare, price calculator, model picker)
- Machine-readable YAML with TypeScript types + Zod validation
- GitHub Action for CI/CD integration
- 76 bilingual docs (38 EN + 38 ZH)

## Why this belongs in 📊 Compare

The Compare section lists "Live benchmarks, pricing, and the latest model versions." AI Models Catalog provides structured, always-updated model pricing, context windows, and capabilities across 95 providers. It complements OpenRouter, LMArena, and Artificial Analysis by providing the raw structured data developers need for model selection.