### PR TITLE
Add APort Agent Guardrails to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
 
+- [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) — Open-source runtime guardrails for AI agents that enforce pre-action authorization and policy checks before tool calls.
+
 ### Evals
 - [OpenAI Evals](https://github.com/openai/evals) — OpenAI's framework for writing evals.
 
@@ -165,3 +167,5 @@ _Stay current without drowning in noise._
 - [AI Engineer](https://newsletter.owainlewis.com)
 
 ---
+
+


### PR DESCRIPTION
## Summary
- Adds APort Agent Guardrails to the Frameworks section.
- Uses the official open-source repository link and a concise description focused on pre-action authorization for AI agent tool calls.

Context: submitted for aporthq/aport-integrations#19.

AI-assisted; reviewed before submission.