### PR TITLE
docs: add n3rv to Agent frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [CrewAI](https://www.crewai.com/) — Agent orchestration with structured tasks and human-in-the-loop controls.
 - [AutoGen](https://microsoft.github.io/autogen/) — Microsoft's framework for multi-agent conversation and collaboration.
 - [LlamaIndex](https://www.llamaindex.ai/) — Data framework for ingesting, indexing, and querying private data with LLMs.
+- [NERV](https://github.com/juanmanueldaza/nerv) — Minimalist agent harness powered by Spec-Driven Development (SDD). Multi-agent orchestration with A2A protocol, persistent ChromaDB memory, and CLI scaffolding. Built for steerability, not complexity.
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The list is reviewed weekly by an evidence-backed automation that independently 
 
 - [Pydantic AI](https://ai.pydantic.dev/): Typed agent development built around Pydantic.
 - [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview): Low-level orchestration for long-running, stateful agents.
+- [n3rv](https://github.com/juanmanueldaza/n3rv): Restraint-oriented agent harness for opencode — Spec-Driven Development, A2A hub, dual-store memory (ChromaDB + SQLite), 14 agent skills, 5 MCP servers, 10 sub-agents. 725+ PyPI installs. Hermes Agent memory provider plugin available.
 - [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/): A small SDK for tools, handoffs, guardrails, tracing, and agent orchestration.
 - [Google Agent Development Kit](https://google.github.io/adk-docs/): Google's framework for developing and evaluating agents.
 - [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/overview/): Microsoft's successor to AutoGen and Semantic Kernel for agents and graph-based workflows.


### PR DESCRIPTION
## 🎨 Agent discovery

**n3rv** is an open-source agent harness built on restraint over orchestration. Spec-Driven Development (SDD), A2A hub, dual-store memory (ChromaDB + SQLite), 14 agent skills, 5 MCP servers, 10 sub-agents.

### Why it fits here

| Criterion | n3rv |
|-----------|------|
| Open-source | ✅ GPL-2.0, 521KB |
| Active | ✅ CI passing, pip-installable, releases |
| Unique angle | SDD-first + MAGI consensus consensus + A2A hub |
| Production-ready | ✅ CLI, daemon, 270+ tests, Hermes plugin available |

725+ PyPI installs across 2 months. Used by fu7ur3pr00f (★7, 4k downloads) and linkedin2md (★36, 6k downloads) as agentic development infrastructure.

### Links
- GitHub: https://github.com/juanmanueldaza/n3rv
- PyPI: https://pypi.org/project/n3rv/
- Docs: https://github.com/juanmanueldaza/n3rv#readme

### Changes from previous PR (#241)
- Rebased onto latest master (was conflicting)
- Renamed from NERV → n3rv (repo was renamed)
- Updated section to match restructured README (now under ### Agent frameworks)
- Added evidence of adoption