### PR TITLE
Add DiamantAI to Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,6 @@ _Stay current without drowning in noise._
 - [AlphaSignal](https://alphasignal.ai/)
 - [Superhuman AI](https://www.superhuman.ai/)
 - [AI Engineer](https://newsletter.owainlewis.com)
+- [DiamantAI](https://diamantai.substack.com)
 
 ---


### PR DESCRIPTION
Adding the DiamantAI newsletter to the Newsletters list.

[DiamantAI](https://diamantai.substack.com) covers practical AI engineering and GenAI (RAG, agents, evals) for builders, with a large developer readership. Fits the engineering focus of this list.

Disclosure: this is my newsletter.