### PR TITLE
Add AI School to Courses (Beginner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _Deep, durable knowledge — still valuable five years from now._
 - [Google Generative AI Learning Path](https://www.cloudskillsboost.google/paths/118)
 - [Hugging Face LLM Course](https://huggingface.co/learn/llm-course/chapter1/1)
 - [Fast.ai — Practical Deep Learning](https://course.fast.ai/)
+- [AI School — Free AI & ML Courses](https://lillytechsystems.com/ai-school/)
 
 **Intermediate / Advanced**
 - [Stanford CS324: Large Language Models](https://stanford-cs324.github.io/winter2022/)


### PR DESCRIPTION
Adds **AI School** to the Courses → Beginner list.

AI School (by Lilly Tech Systems) is a free learning platform with 2,300+ courses and 14,000+ hands-on tutorials covering AI, machine learning, and software engineering — no signup or paywall. It's a good beginner-friendly free resource alongside the existing entries (Hugging Face LLM Course, Fast.ai).

- One entry added under **Beginner**, matching the existing link-only format.
- Link: https://lillytechsystems.com/ai-school/

Thanks for maintaining this list!