### PR TITLE
Add Genesis 2 Cascade MoE neural network framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [LlamaIndex](https://www.llamaindex.ai/) — Data framework for ingesting, indexing, and querying private data with LLMs.
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐
+- [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) — Patented Cascade MoE neural network with shared neuron pool. CPU-only, zero catastrophic forgetting, 18ms inference, 10,800+ experts.
 
 ### Evals
 - [OpenAI Evals](https://github.com/openai/evals) — OpenAI's framework for writing evals.
@@ -165,3 +166,4 @@ _Stay current without drowning in noise._
 - [AI Engineer](https://newsletter.owainlewis.com)
 
 ---
+


### PR DESCRIPTION
## Summary

Adds **Genesis 2** to the Frameworks section under **Build**.

- Genesis 2 is a novel neural network architecture based on **Cascade Mixture-of-Experts (MoE)** with a shared neuron pool — a patented approach filed with FIPS (Russia) in May 2026.
- Key technical properties that distinguish it from existing entries:
  - **CPU-only inference** at 18ms — no GPU required
  - **Zero catastrophic forgetting** via dedicated neuron state management
  - **10,800+ experts** with cascade activation (only relevant experts fire per token)
  - Open-source on GitHub

### Entry added

```
- [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) - Patented Cascade MoE neural network with shared neuron pool. CPU-only, zero catastrophic forgetting, 18ms inference, 10,800+ experts.
```

Placed after Docling in the Frameworks section as it is a self-contained neural network framework (not an agent harness or LLM API wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)