### PR TITLE
Add Meridian Institute of AI to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _Deep, durable knowledge — still valuable five years from now._
 
 ### Courses
 
+* [Meridian Institute of AI](https://meridianinstituteai.com) - 20 free AI courses with certificates covering foundations, prompt engineering, machine learning, agents, and domain applications in finance, law, healthcare, and cybersecurity.
 **Beginner**
 - [Google Generative AI Learning Path](https://www.cloudskillsboost.google/paths/118)
 - [Hugging Face LLM Course](https://huggingface.co/learn/llm-course/chapter1/1)


### PR DESCRIPTION
## What

Adding [Meridian Institute of AI](https://meridianinstituteai.com) to the Courses section.

## Why

Meridian is a free, structured AI education platform with 20 full courses and verifiable certificates. Content covers AI foundations, machine learning, prompt engineering, AI agents, AI safety, and domain applications across finance, law, healthcare, cybersecurity, governance, and more. All courses are free to start with no paywall on foundational content.