### PR TITLE
Add Doubleword CUDA kernel walkthrough to Guides & Playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [Google Agents Companion Paper](https://www.kaggle.com/whitepaper-agent-companion) — Companion guide from Google.
 - [OpenAI Cookbook](https://cookbook.openai.com/) — Example code, recipes, and best practices for working with OpenAI APIs.
 - [LLM Engineer Handbook](https://github.com/SylphAI-Inc/LLM-engineer-handbook) — A goldmine of useful links for AI engineers.
+- [What Happens When You Run a CUDA Kernel (Doubleword)](https://blog.doubleword.ai/what-happens-when-you-run-a-cuda-kernel) — Traces a simple GPU kernel from compilation through the driver stack down to warp scheduling.
 
 ### Frameworks
 - [PocketFlow](https://the-pocket.github.io/PocketFlow/) — Extremely minimalist AI agent framework in just 100 lines of code. Fantastic way to learn.


### PR DESCRIPTION
## Summary

Adds one entry to **🛠 Build → Guides & Playbooks**: a Doubleword engineering deep-dive that traces a simple CUDA kernel from compilation through the NVIDIA driver stack down to warp scheduling on the GPU.

## Why

The Guides & Playbooks list already collects durable technical explainers (e.g. Anthropic's "Building Effective Agents", the OpenAI Cookbook). This post is a broadly-useful, source-level walkthrough of how GPU code actually executes — helpful context for anyone deploying or serving models. It is a single, high-signal resource that matches the section's tone and format.

## Test plan

Not run — docs-only change (one Markdown list line). Verified the link resolves and the entry matches the exact format of neighboring entries (`- [Title](URL) — Description.`).

## Risks

Minimal: one added list item; no existing content changed.

## Related issue

None.