### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _Personal note: you don't need tons of frameworks — start with simple LLM call
 - [LangGraph](https://www.langchain.com/langgraph) — Build multi-agent workflows with stateful graphs on top of LangChain.
 - [CrewAI](https://www.crewai.com/) — Agent orchestration with structured tasks and human-in-the-loop controls.
 - [AutoGen](https://microsoft.github.io/autogen/) — Microsoft's framework for multi-agent conversation and collaboration.
+- [LLMGraph](https://llmgraph.ai) — No-code visual builder for LLM workflows and agents; one-click deploy to a REST API and chat widget.
 - [LlamaIndex](https://www.llamaindex.ai/) — Data framework for ingesting, indexing, and querying private data with LLMs.
 - [Haystack](https://haystack.deepset.ai/) — Open-source search/RAG framework with modular pipelines.
 - [Docling](https://github.com/docling-project/docling) — Great library for ingesting any kind of document for RAG ⭐


### PR DESCRIPTION
## Summary

Adds [LLMGraph](https://llmgraph.ai) to Build → Frameworks — a no-code visual builder for LLM workflows and agents, with one-click deploy to a REST API and chat widget.

## Why

The Frameworks section covers workflow/agent orchestration (LangGraph, CrewAI, AutoGen); LLMGraph fills the no-code/visual end of that spectrum. Disclosure: I'm the founder.

## Test plan

Verified the link resolves and the entry matches the list's format (em dash, one-line description, trailing period). Not otherwise testable.

## Risks

None — single README line.

## Related issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)