### PR TITLE
Add Tura coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ _For live capability comparison, see [Terminal-Bench](https://www.tbench.ai/lead
 - [Pi](https://pi.dev/) — Highly customizable terminal harness; minimal base prompt, extension-driven.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) — Private, local-first agent for Ollama and LM Studio.
 - [Kilo CLI](https://kilo.ai/cli) — Multi-mode agent with a unified gateway to 500+ models.
+- [Tura](https://github.com/Tura-AI/tura) — Local-first open-source Rust agent with CLI, TUI, and GUI interfaces, checkpoints, verification, and reproducible benchmarks.
 
 ---
 


### PR DESCRIPTION
## Summary

Add Tura to Agents > Coding.

## Why

Tura is an actively maintained, local-first open-source Rust coding agent. It complements the existing terminal harnesses with CLI, TUI, and GUI interfaces, checkpoints, a built-in verification workflow, and reproducible public benchmarks.

## Test plan

- Searched README for an existing Tura entry
- Ran `git diff --check`
- Confirmed the entry is in Agents > Coding

## Risks

Low: documentation-only single-line addition.

## Related issue

None.