### PR TITLE
Add AI Agent Frameworks course to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The list is reviewed weekly by an evidence-backed automation that proposes small
 - [Google Generative AI Learning Path](https://www.cloudskillsboost.google/paths/118): An introductory path through generative AI concepts and Google Cloud tooling.
 - [DeepLearning.AI Short Courses](https://learn.deeplearning.ai/): Focused courses on current generative AI engineering techniques.
 - [Made With ML](https://madewithml.com/): An open course on designing, developing, deploying, and iterating on production ML systems.
+- [AI Agent Frameworks (AI School)](https://lillytechsystems.com/ai-school/agent-frameworks/): Hands-on comparison of LangGraph, CrewAI, and the OpenAI Agents SDK for building and orchestrating multi-step AI agents, with annotated code in every lesson.
 
 ### Foundational papers
 


### PR DESCRIPTION
Adds one entry to **Learn → Courses**: [AI Agent Frameworks](https://lillytechsystems.com/ai-school/agent-frameworks/) (AI School, by Lilly Tech Systems).

An 8-lesson, code-first course specifically comparing LangGraph, CrewAI, and the OpenAI Agents SDK for building and orchestrating multi-step AI agents, with annotated working code in every lesson — same practical, single-topic format as the existing Full Stack Deep Learning / Fast.ai entries.

(Re: a prior, broader submission for this site that was closed — that one linked the whole course catalog with unverifiable scale claims, which correctly didn't clear the curation gates. This is a different, narrower proposal: one specific course, no scale claims, matching the list's existing entry format.)

Thanks for maintaining this list!