### PR TITLE
Add Atomic Agent to Coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Coding agents help developers plan, implement, review, test, and debug software.
 - [OpenHands](https://docs.all-hands.dev/): An open-source platform for running software development agents locally or in the cloud.
 - [Cline](https://github.com/cline/cline): An open-source coding agent available as an editor extension, CLI, and SDK.
 - [Continue](https://www.continue.dev/): Open-source coding agents for IDE and CI workflows with source-controlled configuration.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): An open-source, local-first terminal and TUI coding agent that runs open-weight models entirely on your machine with no account or API key required.
 
 ### Software factories and agent orchestration
 


### PR DESCRIPTION
## Summary

Adds Atomic Agent to the Coding agents list: an open-source, local-first terminal and TUI coding agent that runs open-weight models entirely on your machine, with no account or API key required.

## Why

I am the CPO of Atomic Agent, so I am disclosing that affiliation up front. I think it earns a spot here for a reason the current list does not yet cover: every other coding agent in the section leans on a hosted model or a provider key, and Atomic Agent is built to run open-weight models directly on the developer's machine via a llama.cpp fork. For engineers who work offline, on private code, or on regulated repositories, that is a different tool, not a different logo.

It is a real working agent, not a homepage: MIT-licensed, ~1.8k stars, active development, macOS/Linux/Windows, 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory. One-line install and it is running.

- Repository: https://github.com/AtomicBot-ai/atomic-agent
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Community: https://x.com/atomicagent_io and https://discord.gg/Us7qXtDGw

## Test plan

Ran the repository validator locally against my change:
`python scripts/validate_readme.py README.md --check-links --base origin/master` -> 0 errors, exit 0. Structure, duplicate title/URL, churn limits, and the live-link check on the new entry all pass.

## Risks

Low. A single added line under an existing category; no existing entries are reordered or edited. One net-new entry, well within the weekly churn limits.

## Related issue

None.
