### PR TITLE
docs: use neutral resource language

### DIFF
--- a/CURATION.md
+++ b/CURATION.md
@@ -29,14 +29,6 @@ Out of scope unless there is exceptional, pillar-specific engineering value:
 - early demos with little documentation, maintenance evidence, or working implementation;
 - resources whose main value is unrelated to developers building or using AI systems.
 
-## First-party resources
-
-The maintainer may include a small number of his own resources when they are unusually relevant to the three pillars. Ownership must be clear in the description or surrounding text. This preference never overrides link health, factual accuracy, maintenance, usefulness, distinctiveness, or the scope gate.
-
-First-party resources still need a score of at least 80. When independent adoption evidence is limited, a working implementation, clear documentation, tests, releases, and direct use in substantive teaching may satisfy the real-world evidence criterion. Ownership alone is not evidence. Preview software must be labelled accurately and may be removed when it stops clearing the bar.
-
-The automation may inspect the maintainer's public repositories and teaching channel during a monthly governance run. It should add teaching material selectively, prefer durable technical lessons over announcements, and avoid turning the README into a promotional feed.
-
 ## Hard gates
 
 Reject a resource if any of these are true:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is not a comprehensive directory of AI products. Every entry must clear an 
 
 The list is reviewed weekly by an evidence-backed automation that independently reviews, validates, and merges small changes. See [how resources are evaluated](CURATION.md).
 
-For a guided starting point, get Owain Lewis's [free AI Engineer starter pack](https://aiengineer.co/start), which includes agent skills, $1M+ in software discounts and tutorial code. 
+For a guided starting point, get the [free AI Engineer starter pack](https://aiengineer.co/start), which includes agent skills, $1M+ in software discounts and tutorial code.
 
 ## Learn
 
@@ -37,7 +37,7 @@ For a guided starting point, get Owain Lewis's [free AI Engineer starter pack](h
 
 ### Courses
 
-- [AI Engineer](https://aiengineer.co/): Owain Lewis's paid program for agentic coding and building, testing, and shipping production AI systems.
+- [AI Engineer](https://aiengineer.co/): A paid program for agentic coding and building, testing, and shipping production AI systems.
 - [Hugging Face LLM Course](https://huggingface.co/learn/llm-course/chapter1/1): Transformers, fine-tuning, datasets, and modern NLP tooling.
 - [Full Stack Deep Learning](https://fullstackdeeplearning.com/): The full lifecycle of building and shipping AI products.
 - [Fast.ai Practical Deep Learning](https://course.fast.ai/): A code-first introduction to deep learning.
@@ -122,7 +122,7 @@ Coding agents help developers plan, implement, review, test, and debug software.
 
 ### Coding agents
 
-- [Neo](https://github.com/owainlewis/neo): Owain Lewis's open-source, workflow-first terminal coding agent with subagents, skills, sandboxed tools, and multiple model providers.
+- [Neo](https://github.com/owainlewis/neo): An open-source, workflow-first terminal coding agent with subagents, skills, sandboxed tools, and multiple model providers.
 - [Claude Code](https://code.claude.com/): A terminal agent with hooks, subagents, skills, and repository-level instructions.
 - [Codex CLI](https://github.com/openai/codex): An open-source terminal agent with sandbox and approval controls.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli): An open-source terminal agent built around Gemini and extensible tools.
@@ -138,7 +138,7 @@ For a worked implementation, watch [Build Your Own Coding Agent Like Pi](https:/
 
 ### Agent skills and workflows
 
-- [Blueprint](https://github.com/owainlewis/blueprint/tree/main/skills): Owain Lewis's open-source set of focused agent skills for designing, implementing, testing, reviewing, and shipping software changes.
+- [Blueprint](https://github.com/owainlewis/blueprint/tree/main/skills): An open-source set of focused agent skills for designing, implementing, testing, reviewing, and shipping software changes.
 
 ### Software factories and agent orchestration
 
@@ -146,7 +146,7 @@ For a worked implementation, watch [Build Your Own Coding Agent Like Pi](https:/
 - [Codex Orchestration with Symphony](https://openai.com/index/open-source-codex-orchestration-symphony/): A reference architecture that turns project work into isolated, observable coding-agent runs.
 - [How We Built Our Multi-Agent Research System](https://www.anthropic.com/engineering/multi-agent-research-system): Production lessons on orchestrator-worker agents, parallel search, evaluation, and operational reliability.
 
-The maintainer is also building [Factory](https://github.com/owainlewis/factory), a developer-preview control plane for scheduling and coordinating Pi, Codex, and Claude Code workers across Git repositories.
+[Factory](https://github.com/owainlewis/factory) is a developer-preview control plane for scheduling and coordinating Pi, Codex, and Claude Code workers across Git repositories.
 
 ## Contributing
 
@@ -162,4 +162,4 @@ A proposed resource should:
 
 Explain which developer problem the resource solves and why it clears the rubric. If it overlaps an existing entry, explain why it is materially better. Disclose any affiliation with the resource.
 
-For ongoing practical tutorials about coding agents and AI engineering, follow [Owain Lewis on YouTube](https://www.youtube.com/@owainlewis/videos).
+For ongoing practical tutorials about coding agents and AI engineering, visit the [AI Engineer YouTube channel](https://www.youtube.com/@owainlewis/videos).


### PR DESCRIPTION
## Summary

- remove owner-specific wording from the newly added README links
- remove the first-party resource exception from CURATION.md
- keep every requested link while applying the same scope, evidence, maintenance, and scoring rules to all resources

This is a focused follow-up to #281.

## Test plan

- python3 -m unittest discover -s tests -v
- python3 scripts/validate_readme.py README.md --base origin/master
- python3 scripts/validate_readme.py README.md --check-links --base origin/master
- git diff --check origin/master...HEAD

All checks pass. The validator reports 77 resources with 0 errors and 0 warnings.

## Affiliation

The changed links are associated with the repository owner, but the copy and policy now treat them exactly like every other resource.